### PR TITLE
change: stepfun calling route to minimax and liquidAI since stepfun3.…

### DIFF
--- a/src/components/QuizView.tsx
+++ b/src/components/QuizView.tsx
@@ -33,6 +33,8 @@ type QuizState = 'config' | 'loading' | 'active' | 'review';
 export const QuizView: React.FC<QuizViewProps> = ({ 
   language, history, memory, encryptedApiKey, onBack, onExplainRequest, onAddToMemory 
 }) => {
+  const difficultyLevels: QuizConfig["level"][] = ["Fundamental", "Intermediate", "Advanced"];
+
   // --- State ---
   const [viewState, setViewState] = useState<QuizState>('config');
   const [config, setConfig] = useState<QuizConfig>({ level: 'Intermediate', count: 5, mcqRatio: 0.5 });
@@ -214,17 +216,17 @@ export const QuizView: React.FC<QuizViewProps> = ({
             <div>
               <label className="block text-sm font-medium mb-2 text-slate-700 dark:text-slate-300">{LD.ui.difficultyLevel}</label>
               <div className="grid grid-cols-3 gap-2">
-                {LD.ui.difficultyOptions.map((l) => (
+                {difficultyLevels.map((level, index) => (
                   <button
-                    key={l}
-                    onClick={() => setConfig({ ...config, level: l as any })}
+                    key={level}
+                    onClick={() => setConfig({ ...config, level })}
                     className={`py-2 px-3 rounded-lg text-sm transition-all ${
-                      config.level === l 
+                      config.level === level
                         ? 'bg-indigo-600 text-white shadow-md' 
                         : 'bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-400 hover:bg-slate-200'
                     }`}
                   >
-                    {l}
+                    {LD.ui.difficultyOptions[index] ?? level}
                   </button>
                 ))}
               </div>

--- a/src/pages/changelog/changelog.json
+++ b/src/pages/changelog/changelog.json
@@ -1,5 +1,13 @@
 [
   {
+    "version": "2.3.6.5",
+    "date": "2026-04-10",
+    "changes": [
+      { "type": "improve", "text": "Introduced LiquidAI Instruct and MiniMax 2.5 for race modes, replacing StepFun 3.5 now that the free tier is no longer available." },
+      { "type": "fix", "text": "Resolved Quiz level state consistency issues across supported languages." }
+    ]
+  },
+  {
     "version": "2.3.6",
     "date": "2026-04-06",
     "changes": [

--- a/src/services/geminiService.ts
+++ b/src/services/geminiService.ts
@@ -59,6 +59,26 @@ type estimateQuizConfigResponse = {
   mcqRatio: number;
 };
 
+const normalizeQuizLevel = (level: unknown): QuizConfig["level"] | null => {
+  if (typeof level !== "string") return null;
+
+  const normalized = level.trim().toLowerCase();
+
+  if (["fundamental", "fondamental", "cơ bản", "co ban"].includes(normalized)) {
+    return "Fundamental";
+  }
+
+  if (["intermediate", "intermédiaire", "intermediaire", "intermedio", "trung cấp", "trung cap"].includes(normalized)) {
+    return "Intermediate";
+  }
+
+  if (["advanced", "avancé", "avance", "avanzado", "nâng cao", "nang cao"].includes(normalized)) {
+    return "Advanced";
+  }
+
+  return null;
+};
+
 type TemperatureEstimationResponse = {
   temperature: number;
 };
@@ -319,7 +339,7 @@ export const sleep = (ms: number) =>
   new Promise<void>(resolve => setTimeout(resolve, ms));
 
 type EdgeCallParams = {
-  provider: "gemini" | "stepfun";
+  provider: "gemini" | "openrouter";
   model: string;
   prompt: string;
   temp?: number;
@@ -401,9 +421,9 @@ const getGeminiTextFromEdge = async (params: Omit<EdgeCallParams, "provider">) =
   return text;
 };
 
-const getStepFunTextFromEdge = async (params: Omit<EdgeCallParams, "provider">) => {
+const getOpenRouterTextFromEdge = async (params: Omit<EdgeCallParams, "provider">) => {
   const response = await invokeEdgeAI({
-    provider: "stepfun",
+    provider: "openrouter",
     ...params,
   });
 
@@ -463,16 +483,40 @@ export const sendMessageToBotRace = async (params: {
     return { model, text };
   };
 
-  const callStepFun = async () => {
-    const text = await getStepFunTextFromEdge({
-      model: "stepfun/step-3.5-flash:free",
+  // const callStepFun = async () => {
+  //   const text = await getOpenRouterTextFromEdge({
+  //     model: "stepfun/step-3.5-flash:free",
+  //     prompt,
+  //     temp,
+  //     mode: "chat",
+  //     language: resolvedLanguage,
+  //   });
+
+  //   return { model: "stepfun-3.5-flash", text };
+  // };
+
+  const callMiniMax = async () => {
+    const text = await getOpenRouterTextFromEdge({
+      model: "minimax/minimax-m2.5:free",
       prompt,
       temp,
       mode: "chat",
       language: resolvedLanguage,
     });
 
-    return { model: "stepfun-3.5-flash", text };
+    return { model: "minimax-m2.5", text };
+  };
+
+  const callLiquidAI = async () => {
+    const text = await getOpenRouterTextFromEdge({
+      model: "liquid/lfm-2.5-1.2b-instruct:free",
+      prompt,
+      temp,
+      mode: "chat",
+      language: resolvedLanguage,
+    });
+
+    return { model: "liquid-instruct", text };
   };
 
   try {
@@ -481,7 +525,7 @@ export const sendMessageToBotRace = async (params: {
     if (intent === "agentic") {
       console.log("Using agentic strategy for this request");
       raceResult = await raceModels([
-        () => callStepFun(),
+        () => callMiniMax(),
         () => callGemini("gemini-3-flash-preview")
       ]);
     }
@@ -489,14 +533,14 @@ export const sendMessageToBotRace = async (params: {
       console.log("Using fast strategy for this request");
       raceResult = await raceModels([
         () => callGemini("gemini-2.5-flash-lite"),
-        () => callStepFun()
+        () => callLiquidAI()
       ]);
     }
     else {
       console.log("Using balanced strategy for this request");
       raceResult = await raceModels([
         () => callGemini("gemini-3-flash-preview"),
-        () => callStepFun()
+        () => callMiniMax()
       ]);
     }
 
@@ -717,10 +761,10 @@ ${history.map((h) => `${h.role.toUpperCase()}: ${h.content}`).join("\n\n")}
 };
 
 // 2. NEW: Estimate Quiz Configuration based on Chat Context
-export const estimateQuizConfig = async (
+export const estimateQuizConfig = async ( // the config level can cause mismatch language keys, consider add a language param here so that the model can return consistent keys or refactor to use consistent keys across the app
   history: ChatHistoryItem[], 
   memory: string | null,
-  encryptedKeyPayload: any
+  encryptedKeyPayload: any,
 ): Promise<QuizConfig> => {
   const lightMemory = formatOracleMemoryForQuizConfig(memory);
   
@@ -749,11 +793,17 @@ export const estimateQuizConfig = async (
       encryptedKeyPayload,
     });
 
-    if (!isEstimateQuizConfigResponse(JSON.parse(text))) {
+    const parsed = JSON.parse(text);
+    const normalizedLevel = normalizeQuizLevel(parsed?.level);
+    const normalizedConfig = normalizedLevel
+      ? { ...parsed, level: normalizedLevel }
+      : parsed;
+
+    if (!isEstimateQuizConfigResponse(normalizedConfig)) {
       throw new InvalidAIResponseError("Invalid response format for quiz config estimation");
     }
 
-    return JSON.parse(text);
+    return normalizedConfig;
   } catch (err) { // no retry, return default config
     return {
       level: "Fundamental",
@@ -1057,8 +1107,8 @@ const formatInvokeError = (error: any, data: any) => { // debugging purposes
 export const generateSearchQueries = async (
   userPrompt: string
 ): Promise<string[]> => {
-  const text = await getStepFunTextFromEdge({
-    model: "stepfun/step-3.5-flash:free",
+  const text = await getOpenRouterTextFromEdge({
+    model: "liquid/lfm-2.5-1.2b-instruct:free",
     prompt: userPrompt,
     temp: 0.2,
     systemInstruction: QUERY_EXTRACT_PROMPT,


### PR DESCRIPTION
…5 is no longer free, fix: quiz level mismatch across languages

## Summary
Update the current routing system to minimax2.5 and liquidAI models, as stepfun3.5 is no longer free, causing 404 errors for the current v2.3.6 prod

## Changes Made
- Introduced LiquidAI Instruct and MiniMax 2.5 for race modes, replacing StepFun 3.5 now that the free tier is no longer available.
- Resolved Quiz level state consistency issues across supported languages.

## Why This Matters
Explain the reasoning or impact of these changes.

## Testing
- [x] Tested locally
- [x] No console errors
- [x] UI verified
- [x] No breaking changes introduced: Fully compatible with latest version

## Screenshots / Preview
None

## Additional Notes
This is a hot-fix. Docs and README are not yet updated for these changes